### PR TITLE
53 implement darkmode for people with os preference

### DIFF
--- a/public/styles/detail.css
+++ b/public/styles/detail.css
@@ -645,5 +645,27 @@ footer{
 		/* backdrop-filter: brightness(30%); */
 	}
 
+	.btn {	
+		--
+		color: white;
+		border: solid 1px white
+		display: inline-flex; 
+		height: 2.5em;
+		padding: 0 10px;
+		box-sizing: border-box; 
+		min-width: 80px;
+	}
+	
+	/* Specific styles for .share-btn */
+	.share-btn p, .like-btn span {
+		margin: 0;
+		padding: 3px;
+	
+	}
+	
+	.share-btn svg{
+		fill: black;
+	}
+
 
 }

--- a/public/styles/detail.css
+++ b/public/styles/detail.css
@@ -642,7 +642,7 @@ footer{
 	}
 
 	.main {
-		backdrop-filter: brightness(60%);
+		/* backdrop-filter: brightness(30%); */
 	}
 
 

--- a/public/styles/detail.css
+++ b/public/styles/detail.css
@@ -629,3 +629,21 @@ footer{
 
 
 }
+
+
+@media (prefers-color-scheme: dark) {
+	
+	.detail-landing-container {
+	background-color: #292825;
+	}
+
+	.author span a {
+		color: white;
+	}
+
+	.main {
+		backdrop-filter: brightness(60%);
+	}
+
+
+}

--- a/public/styles/detail.css
+++ b/public/styles/detail.css
@@ -638,33 +638,20 @@ footer{
 	}
 
 	.author span a {
-		color: white;
+		color: var(--text-dm-color);
 	}
 
-	.main {
+	main {
 		/* backdrop-filter: brightness(30%); */
 	}
 
 	.btn {	
-		--
-		color: white;
-		border: solid 1px white
-		display: inline-flex; 
-		height: 2.5em;
-		padding: 0 10px;
-		box-sizing: border-box; 
-		min-width: 80px;
-	}
-	
-	/* Specific styles for .share-btn */
-	.share-btn p, .like-btn span {
-		margin: 0;
-		padding: 3px;
-	
+		color: var(--text-dm-color);
+		border: solid 1px var(--text-dm-color);
 	}
 	
 	.share-btn svg{
-		fill: black;
+		fill: var(--text-dm-color);
 	}
 
 

--- a/public/styles/header.css
+++ b/public/styles/header.css
@@ -39,6 +39,7 @@ header{
        
        /* mobile-menu-window */
        section#mobile-menu-window {
+        
            display: none;
            flex-direction: column;
            position: fixed;
@@ -68,6 +69,7 @@ header{
        #mobile-menu-window ul li {
            margin: 0em 0em .25em 0em;
            font-weight: 600;
+           font-family: 'Inter', sans serif;
        }
        
        #mobile-menu-window ul li a:hover {
@@ -246,8 +248,54 @@ header{
   }
   }
 
-
 @media (min-width: 60.0625em){
 
     
+}
+
+@media (prefers-color-scheme: dark) {
+
+    
+	body {
+     --background-dm-color:  #121212;
+     --text-dm-color : #FFFFFF;
+	  color: var(--text-dm-color);
+	  background: var(--background-dm-color);
+	}
+
+    .menu-open svg path,
+    .search-icon svg path {
+        stroke: var(--text-dm-color);
+    }
+
+
+     /* mobile-menu-window */
+    section#mobile-menu-window {
+        background-color: var(--background-dm-color);
+
+        li a {
+            color: var(--text-dm-color)
+        }
+    }
+
+    #mobile-menu-window .menu-exit svg path {
+        stroke: var(--text-dm-color);
+    }
+
+    .newsletter svg{
+        fill: var(--text-dm-color);
+    }
+
+    .theme svg path {
+       fill: var(--text-dm-color);
+    }
+
+    .second-row  {
+        border-top: solid 1px white;
+        border-bottom: solid 1px white;
+    }
+
+    .desktop-pages a{
+        color: var(--text-dm-color);
+    }
 }

--- a/public/styles/header.css
+++ b/public/styles/header.css
@@ -290,6 +290,10 @@ header{
        fill: var(--text-dm-color);
     }
 
+    .desktop-pages svg {
+        fill: white;
+    }
+
     .second-row  {
         border-top: solid 1px white;
         border-bottom: solid 1px white;

--- a/public/styles/home-page.css
+++ b/public/styles/home-page.css
@@ -463,8 +463,8 @@ footer{
 }
 
 @media (prefers-color-scheme: dark) {
-	body {
-	  color: #eee;
-	  background: #121212;
+	
+	section.carousel .post-title {
+		color: var(--text-dm-color);
 	}
 }

--- a/public/styles/home-page.css
+++ b/public/styles/home-page.css
@@ -462,3 +462,9 @@ footer{
 
 }
 
+@media (prefers-color-scheme: dark) {
+	body {
+	  color: #eee;
+	  background: #121212;
+	}
+}

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -309,6 +309,12 @@ footer{
 
 }
 
+@media (prefers-color-scheme: dark) {
+	body {
+	  color: #FFFFFF;
+	  background: #121212;
+	}
+}
 
 /* #region Keyframe animations */ 
 


### PR DESCRIPTION
# Darkmode on OS for home and detailpage 

Added media query for header, homepage and detailpage with styling for our darkmode which is almost complete. 

<img width="500px" src="https://github.com/fdnd-task/pleasurable-ui/assets/143999883/cb54966a-e123-4a37-96de-8bac7437dc0a">

***

**Fix after merge :**

- Category banner styling in home-page.css 
- Button styling in detail.css

I cant edit these elements now because there is updated code which I havent merged so Ill change these things after this pull request. 

